### PR TITLE
Fixed result merge for Google's result format

### DIFF
--- a/Assistant/module.php
+++ b/Assistant/module.php
@@ -180,10 +180,10 @@ class Assistant extends IPSModule
         $this->SendDebug('Results', print_r($results, true), 0);
         foreach ($results as $result) {
             $found = false;
-            foreach ($commands as $command) {
+            foreach ($commands as $index => $command) {
                 //lets assume for now there can only be one result per state
                 if ($command['states'] == $result['states']) {
-                    $command['ids'] = array_merge($command['ids'], $result['ids']);
+                    $commands[$index]['ids'] = array_merge($commands[$index]['ids'], $result['ids']);
                     $found = true;
                 }
             }


### PR DESCRIPTION
In the original implementaion, only a copy of the array was modified leaving the original array untouched.